### PR TITLE
RELATED: ONE-3610 Support for textual filters in AFM typings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,9 @@
-// Copyright (C) 2007-2017, GoodData(R) Corporation. All rights reserved.
+// (C) 2007-2019 GoodData Corporation
 
 export * from './src/AFM';
+export * from './src/ExecuteAFM';
 export * from './src/Execution';
+export * from './src/VisualizationInput';
 export * from './src/VisualizationObject';
 export * from './src/VisualizationClass';
 export * from './src/Localization';

--- a/src/ExecuteAFM.ts
+++ b/src/ExecuteAFM.ts
@@ -1,20 +1,15 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2019 GoodData Corporation
 import isEmpty = require('lodash/isEmpty');
 
 /**
- * Types defined here are client-side representation of the AFM. This representation MAY differ from the
- * physical representation of the AFM accepted by the REST API.
- *
- * The intended use is that client code uses exclusively types defined in this namespace. Functions or methods
- * that communicate with executeAfm REST API endpoint MUST transform this AFM to a structure acceptable by
- * the backend.
+ * Types defined here exactly match types accepted by the executeAfm resource.
  *
  * >>> Note for developers: when you modify these structures, be sure to update gooddata-js execute-afm.convert.ts
- * with conversion of the new/updated construct to ExecuteAFM types accepted by backend.
+ * with conversion from AFM types to the new/updated construct.
  *
- * @see ./ExecuteAFM
+ * Types currently map executeAfm version 3.
  */
-export namespace AFM {
+export namespace ExecuteAFM {
     export interface IExecution {
         execution: {
             afm: IAfm;
@@ -99,7 +94,6 @@ export namespace AFM {
         periodsAgo: number;
     }
 
-    // ObjQualifier type
     export type Identifier = string;
     export type ObjQualifier = IObjUriQualifier | IObjIdentifierQualifier;
 
@@ -111,25 +105,32 @@ export namespace AFM {
         uri: string;
     }
 
-    // Filter types and interfaces
     export type CompatibilityFilter = IExpressionFilter | FilterItem;
     export type FilterItem = DateFilterItem | AttributeFilterItem;
     export type AttributeFilterItem = IPositiveAttributeFilter | INegativeAttributeFilter;
     export type DateFilterItem = IAbsoluteDateFilter | IRelativeDateFilter;
 
+    export interface IAttributeElementsByRef {
+        uris: string[];
+    }
+
+    export interface IAttributeElementsByValue {
+        values: string[];
+    }
+
+    export type AttributeElements = string[] | IAttributeElementsByRef | IAttributeElementsByValue;
+
     export interface IPositiveAttributeFilter {
         positiveAttributeFilter: {
             displayForm: ObjQualifier;
-            in: string[];
-            textFilter?: boolean;
+            in: AttributeElements;
         };
     }
 
     export interface INegativeAttributeFilter {
         negativeAttributeFilter: {
             displayForm: ObjQualifier;
-            notIn: string[];
-            textFilter?: boolean;
+            notIn: AttributeElements;
         };
     }
 
@@ -150,7 +151,7 @@ export namespace AFM {
         };
     }
 
-    // Might be removed, as we don't know if expression filter is needed
+// Might be removed, as we don't know if expression filter is needed
     export interface IExpressionFilter {
         value: string;
     }
@@ -222,72 +223,116 @@ export namespace AFM {
         };
     }
 
-    export function isObjectUriQualifier(qualifier: AFM.ObjQualifier): qualifier is AFM.IObjUriQualifier {
-        return !isEmpty(qualifier) && (qualifier as AFM.IObjUriQualifier).uri !== undefined;
+    export function isObjectUriQualifier(
+        qualifier: ExecuteAFM.ObjQualifier
+    ): qualifier is ExecuteAFM.IObjUriQualifier {
+        return !isEmpty(qualifier) && (qualifier as ExecuteAFM.IObjUriQualifier).uri !== undefined;
     }
 
-    export function isObjIdentifierQualifier(qualifier: AFM.ObjQualifier): qualifier is AFM.IObjIdentifierQualifier {
-        return !isEmpty(qualifier) && (qualifier as AFM.IObjIdentifierQualifier).identifier !== undefined;
+    export function isObjIdentifierQualifier(
+        qualifier: ExecuteAFM.ObjQualifier
+    ): qualifier is ExecuteAFM.IObjIdentifierQualifier {
+        return !isEmpty(qualifier) && (qualifier as ExecuteAFM.IObjIdentifierQualifier).identifier !== undefined;
     }
 
     export function isSimpleMeasureDefinition(
-        definition: AFM.MeasureDefinition
-    ): definition is AFM.ISimpleMeasureDefinition {
-        return !isEmpty(definition) && (definition as AFM.ISimpleMeasureDefinition).measure !== undefined;
+        definition: ExecuteAFM.MeasureDefinition
+    ): definition is ExecuteAFM.ISimpleMeasureDefinition {
+        return !isEmpty(definition) && (definition as ExecuteAFM.ISimpleMeasureDefinition).measure !== undefined;
     }
 
     export function isArithmeticMeasureDefinition(
-        definition: AFM.MeasureDefinition
-    ): definition is AFM.IArithmeticMeasureDefinition {
-        return !isEmpty(definition) && (definition as AFM.IArithmeticMeasureDefinition).arithmeticMeasure !== undefined;
+        definition: ExecuteAFM.MeasureDefinition
+    ): definition is ExecuteAFM.IArithmeticMeasureDefinition {
+        return !isEmpty(definition)
+            && (definition as ExecuteAFM.IArithmeticMeasureDefinition).arithmeticMeasure !== undefined;
     }
 
     export function isPopMeasureDefinition(
-        definition: AFM.MeasureDefinition
-    ): definition is AFM.IPopMeasureDefinition {
-        return !isEmpty(definition) && (definition as AFM.IPopMeasureDefinition).popMeasure !== undefined;
+        definition: ExecuteAFM.MeasureDefinition
+    ): definition is ExecuteAFM.IPopMeasureDefinition {
+        return !isEmpty(definition) && (definition as ExecuteAFM.IPopMeasureDefinition).popMeasure !== undefined;
     }
 
     export function isPreviousPeriodMeasureDefinition(
-        definition: AFM.MeasureDefinition
-    ): definition is AFM.IPreviousPeriodMeasureDefinition {
+        definition: ExecuteAFM.MeasureDefinition
+    ): definition is ExecuteAFM.IPreviousPeriodMeasureDefinition {
         return !isEmpty(definition)
-            && (definition as AFM.IPreviousPeriodMeasureDefinition).previousPeriodMeasure !== undefined;
+            && (definition as ExecuteAFM.IPreviousPeriodMeasureDefinition).previousPeriodMeasure !== undefined;
     }
 
-    export function isAttributeSortItem(sortItem: AFM.SortItem): sortItem is AFM.IAttributeSortItem {
-        return !isEmpty(sortItem) && (sortItem as AFM.IAttributeSortItem).attributeSortItem !== undefined;
+    export function isAttributeSortItem(
+        sortItem: ExecuteAFM.SortItem
+    ): sortItem is ExecuteAFM.IAttributeSortItem {
+        return !isEmpty(sortItem) && (sortItem as ExecuteAFM.IAttributeSortItem).attributeSortItem !== undefined;
     }
 
-    export function isMeasureSortItem(sortItem: AFM.SortItem): sortItem is AFM.IMeasureSortItem {
-        return !isEmpty(sortItem) && (sortItem as AFM.IMeasureSortItem).measureSortItem !== undefined;
+    export function isMeasureSortItem(
+        sortItem: ExecuteAFM.SortItem
+    ): sortItem is ExecuteAFM.IMeasureSortItem {
+        return !isEmpty(sortItem) && (sortItem as ExecuteAFM.IMeasureSortItem).measureSortItem !== undefined;
     }
 
-    export function isMeasureLocatorItem(locator: AFM.LocatorItem): locator is AFM.IMeasureLocatorItem {
-        return !isEmpty(locator) && (locator as AFM.IMeasureLocatorItem).measureLocatorItem !== undefined;
+    export function isMeasureLocatorItem(
+        locator: ExecuteAFM.LocatorItem
+    ): locator is ExecuteAFM.IMeasureLocatorItem {
+        return !isEmpty(locator)
+            && (locator as ExecuteAFM.IMeasureLocatorItem).measureLocatorItem !== undefined;
     }
 
-    export function isDateFilter(filter: AFM.CompatibilityFilter): filter is AFM.DateFilterItem {
+    export function isDateFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.DateFilterItem {
         return !isEmpty(filter) && (isRelativeDateFilter(filter) || isAbsoluteDateFilter(filter));
     }
 
-    export function isRelativeDateFilter(filter: AFM.CompatibilityFilter): filter is AFM.IRelativeDateFilter {
+    export function isRelativeDateFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.IRelativeDateFilter {
         return !isEmpty(filter) && (filter as IRelativeDateFilter).relativeDateFilter !== undefined;
     }
 
-    export function isAbsoluteDateFilter(filter: AFM.CompatibilityFilter): filter is AFM.IAbsoluteDateFilter {
+    export function isAbsoluteDateFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.IAbsoluteDateFilter {
         return !isEmpty(filter) && (filter as IAbsoluteDateFilter).absoluteDateFilter !== undefined;
     }
 
-    export function isAttributeFilter(filter: AFM.CompatibilityFilter): filter is AFM.AttributeFilterItem {
+    export function isAttributeFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.AttributeFilterItem {
         return !isEmpty(filter) && (isPositiveAttributeFilter(filter) || isNegativeAttributeFilter(filter));
     }
 
-    export function isPositiveAttributeFilter(filter: AFM.CompatibilityFilter): filter is AFM.IPositiveAttributeFilter {
-        return !isEmpty(filter) && (filter as AFM.IPositiveAttributeFilter).positiveAttributeFilter !== undefined;
+    export function isPositiveAttributeFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.IPositiveAttributeFilter {
+        return !isEmpty(filter)
+            && (filter as ExecuteAFM.IPositiveAttributeFilter).positiveAttributeFilter !== undefined;
     }
 
-    export function isNegativeAttributeFilter(filter: AFM.CompatibilityFilter): filter is AFM.INegativeAttributeFilter {
-        return !isEmpty(filter) && (filter as AFM.INegativeAttributeFilter).negativeAttributeFilter !== undefined;
+    export function isNegativeAttributeFilter(
+        filter: ExecuteAFM.CompatibilityFilter
+    ): filter is ExecuteAFM.INegativeAttributeFilter {
+        return !isEmpty(filter)
+            && (filter as ExecuteAFM.INegativeAttributeFilter).negativeAttributeFilter !== undefined;
+    }
+
+    export function isAttributeElementsArray(attributeElements: AttributeElements): attributeElements is string[] {
+        return attributeElements !== undefined && attributeElements instanceof Array;
+    }
+
+    export function isAttributeElementsByRef(
+        attributeElements: ExecuteAFM.AttributeElements
+    ): attributeElements is ExecuteAFM.IAttributeElementsByRef {
+        return !isEmpty(attributeElements)
+            && (attributeElements as ExecuteAFM.IAttributeElementsByRef).uris !== undefined;
+    }
+
+    export function isAttributeElementsByValue(
+        attributeElements: ExecuteAFM.AttributeElements
+    ): attributeElements is ExecuteAFM.IAttributeElementsByValue {
+        return !isEmpty(attributeElements)
+            && (attributeElements as ExecuteAFM.IAttributeElementsByValue).values !== undefined;
     }
 }

--- a/src/VisualizationInput.ts
+++ b/src/VisualizationInput.ts
@@ -1,0 +1,59 @@
+// (C) 2019 GoodData Corporation
+import { AFM } from './AFM';
+import { VisualizationObject } from './VisualizationObject';
+
+/**
+ * This namespace implements types that are used as inputs to various visualization components.
+ *
+ * At the moment these types are mere aliases to types defined in VisualizationObject and/or AFM. This may change
+ * in the future if VisualizationObject and or AFM change incompatibly - in that case we MAY add backward compatible
+ * types here in order not to break existing users.
+ */
+export namespace VisualizationInput {
+    export type IAttribute = VisualizationObject.IVisualizationAttribute;
+    export type IMeasure = VisualizationObject.IMeasure;
+
+    export type AttributeOrMeasure = IAttribute | IMeasure;
+
+    export type IPositiveAttributeFilter = AFM.IPositiveAttributeFilter;
+    export type INegativeAttributeFilter = AFM.INegativeAttributeFilter;
+    export type IAbsoluteDateFilter = VisualizationObject.IVisualizationObjectAbsoluteDateFilter;
+    export type IRelativeDateFilter = VisualizationObject.IVisualizationObjectRelativeDateFilter;
+
+    export type IFilter =
+        IAbsoluteDateFilter
+        | IRelativeDateFilter
+        | IPositiveAttributeFilter
+        | INegativeAttributeFilter;
+
+    export type ISort = AFM.IAttributeSortItem | AFM.IMeasureSortItem;
+    export type ITotal = VisualizationObject.IVisualizationTotal;
+
+    export function isMeasure(obj: any): obj is IMeasure {
+        return VisualizationObject.isMeasure(obj as VisualizationObject.IMeasure);
+    }
+
+    export function isAttribute(obj: any): obj is IAttribute {
+        return VisualizationObject.isAttribute(obj as VisualizationObject.IVisualizationAttribute);
+    }
+
+    export function isPositiveAttributeFilter(obj: any): obj is IPositiveAttributeFilter {
+        return AFM.isPositiveAttributeFilter(obj);
+    }
+
+    export function isNegativeAttributeFilter(obj: any): obj is INegativeAttributeFilter {
+        return AFM.isNegativeAttributeFilter(obj);
+    }
+
+    export function isAbsoluteDateFilter(obj: any): obj is IAbsoluteDateFilter {
+        return VisualizationObject.isAbsoluteDateFilter(obj);
+    }
+
+    export function isRelativeDateFilter(obj: any): obj is IRelativeDateFilter {
+        return VisualizationObject.isRelativeDateFilter(obj);
+    }
+
+    export function isSort(obj: any): obj is ISort {
+        return AFM.isAttributeSortItem(obj) || AFM.isMeasureSortItem(obj);
+    }
+}

--- a/src/VisualizationObject.ts
+++ b/src/VisualizationObject.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { IObjectMeta } from './Meta';
 import isEmpty = require('lodash/isEmpty');
 
@@ -210,6 +210,12 @@ export namespace VisualizationObject {
         filter: VisualizationObjectDateFilter
     ): filter is IVisualizationObjectAbsoluteDateFilter {
         return !isEmpty(filter) && (filter as IVisualizationObjectAbsoluteDateFilter).absoluteDateFilter !== undefined;
+    }
+
+    export function isRelativeDateFilter(
+        filter: VisualizationObjectDateFilter
+    ): filter is IVisualizationObjectRelativeDateFilter {
+        return !isEmpty(filter) && (filter as IVisualizationObjectRelativeDateFilter).relativeDateFilter !== undefined;
     }
 
     export function isAttribute(bucketItem: BucketItem): bucketItem is IVisualizationAttribute {

--- a/src/tests/AFM.test.ts
+++ b/src/tests/AFM.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { AFM } from '../AFM';
 import CompatibilityFilter = AFM.CompatibilityFilter;
 import MeasureDefinition = AFM.MeasureDefinition;
@@ -425,6 +425,222 @@ describe('AFM', () => {
             };
             const result = AFM.isMeasureLocatorItem(locatorItem);
             expect(result).toEqual(true);
+        });
+    });
+
+    describe('isDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isRelativeDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isRelativeDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isRelativeDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isRelativeDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isRelativeDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isAbsoluteDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isAttributeFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isAttributeFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isAttributeFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(false);
         });
     });
 

--- a/src/tests/ExecuteAFM.test.ts
+++ b/src/tests/ExecuteAFM.test.ts
@@ -1,0 +1,384 @@
+// (C) 2019 GoodData Corporation
+import { ExecuteAFM as AFM } from '../ExecuteAFM';
+import CompatibilityFilter = AFM.CompatibilityFilter;
+
+describe('AFM', () => {
+    describe('isDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isRelativeDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isRelativeDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isRelativeDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isRelativeDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isRelativeDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isAbsoluteDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isAttributeFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isAttributeFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isAttributeFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    from: '1',
+                    to: '2'
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when relative date filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/ds'
+                    },
+                    granularity: 'gram',
+                    from: -10,
+                    to: 0
+                }
+            };
+            const result = AFM.isAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isPositiveAttributeFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isPositiveAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isPositiveAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isNegativeAttributeFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when negative attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isNegativeAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const filter: CompatibilityFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = AFM.isNegativeAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isAttributeElementsArray', () => {
+        it ('should return false when null is tested', () => {
+            const result = AFM.isAttributeElementsArray(null);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return false when undefined is tested', () => {
+            const result = AFM.isAttributeElementsArray(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return false when attr elements by ref', () => {
+            const result = AFM.isAttributeElementsArray({ uris: ['a', 'b', 'c'] });
+            expect(result).toEqual(false);
+        });
+        it ('should return false when attr elements by value', () => {
+            const result = AFM.isAttributeElementsArray({ values: ['a', 'b', 'c'] });
+            expect(result).toEqual(false);
+        });
+        it ('should return true when attr elements is array', () => {
+            const result = AFM.isAttributeElementsArray(['a', 'b', 'c']);
+            expect(result).toEqual(true);
+        });
+        it ('should return true when attr elements is empty array', () => {
+            const result = AFM.isAttributeElementsArray([]);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isAttributeElementsByRef', () => {
+        it ('should return false when null is tested', () => {
+            const result = AFM.isAttributeElementsByRef(null);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return false when undefined is tested', () => {
+            const result = AFM.isAttributeElementsByRef(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return true when attr elements by ref', () => {
+            const result = AFM.isAttributeElementsByRef({ uris: ['a', 'b', 'c'] });
+            expect(result).toEqual(true);
+        });
+        it ('should return false when attr elements by value', () => {
+            const result = AFM.isAttributeElementsByRef({ values: ['a', 'b', 'c'] });
+            expect(result).toEqual(false);
+        });
+        it ('should return false when attr elements is array', () => {
+            const result = AFM.isAttributeElementsByRef(['a', 'b', 'c']);
+            expect(result).toEqual(false);
+        });
+        it ('should return false when attr elements is empty array', () => {
+            const result = AFM.isAttributeElementsByRef([]);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isAttributeElementsByValue', () => {
+        it ('should return false when null is tested', () => {
+            const result = AFM.isAttributeElementsByValue(null);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return false when undefined is tested', () => {
+            const result = AFM.isAttributeElementsByValue(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it ('should return false when attr elements by ref', () => {
+            const result = AFM.isAttributeElementsByValue({ uris: ['a', 'b', 'c'] });
+            expect(result).toEqual(false);
+        });
+        it ('should return true when attr elements by value', () => {
+            const result = AFM.isAttributeElementsByValue({ values: ['a', 'b', 'c'] });
+            expect(result).toEqual(true);
+        });
+        it ('should return false when attr elements is array', () => {
+            const result = AFM.isAttributeElementsByValue(['a', 'b', 'c']);
+            expect(result).toEqual(false);
+        });
+        it ('should return false when attr elements is empty array', () => {
+            const result = AFM.isAttributeElementsByValue([]);
+            expect(result).toEqual(false);
+        });
+    });
+});

--- a/src/tests/VisualizationObject.test.ts
+++ b/src/tests/VisualizationObject.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
 import { VisualizationObject } from '../VisualizationObject';
 import IMeasure = VisualizationObject.IMeasure;
 import IVisualizationAttribute = VisualizationObject.IVisualizationAttribute;
@@ -478,6 +478,47 @@ describe('VisualizationObject', () => {
                 }
             };
             const result = VisualizationObject.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isRelativeDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationObject.isRelativeDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationObject.isRelativeDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: VisualizationObjectDateFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    from: 'beginning',
+                    to: 'to end'
+                }
+            };
+            const result = VisualizationObject.isRelativeDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: VisualizationObjectDateFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    granularity: 'GDC.time.year',
+                    from: -1,
+                    to: -1
+                }
+            };
+            const result = VisualizationObject.isRelativeDateFilter(filter);
             expect(result).toEqual(true);
         });
     });


### PR DESCRIPTION
- Adds new types under ExecuteAFM namespace; these 1-1 correspond to what backend needs
- Updated AFM positive/negative filter in a backward compatible fashion, to support text filters
- Adds new types (type aliases) to be used as inputs to visualization components (bucket iterface)