### PR TITLE
FEATURE: ONE-3511 Make layout column content optional

### DIFF
--- a/src/DashboardLayout.ts
+++ b/src/DashboardLayout.ts
@@ -27,7 +27,7 @@ export interface IFluidLayoutRow {
  }
 
 export interface IFluidLayoutColumn {
-    content: LayoutContent;
+    content?: LayoutContent;
     size: IFluidLayoutColSize;
     style?: string;
  }


### PR DESCRIPTION
To support removal of Dashboard visualizations, column content in the
layout object was made optional.