### PR TITLE
RELATED: BB-1780 Add measure value filter to VisualizationInput

### DIFF
--- a/src/AFM.ts
+++ b/src/AFM.ts
@@ -334,4 +334,8 @@ export namespace AFM {
     export function isMeasureValueFilter(filter: AFM.CompatibilityFilter): filter is AFM.IMeasureValueFilter {
         return !isEmpty(filter) && (filter as AFM.IMeasureValueFilter).measureValueFilter !== undefined;
     }
+
+    export function isExpressionFilter(filter: AFM.CompatibilityFilter): filter is AFM.IExpressionFilter {
+        return !isEmpty(filter) && (filter as AFM.IExpressionFilter).value !== undefined;
+    }
 }

--- a/src/ExecuteAFM.ts
+++ b/src/ExecuteAFM.ts
@@ -365,6 +365,10 @@ export namespace ExecuteAFM {
             && (filter as ExecuteAFM.IMeasureValueFilter).measureValueFilter !== undefined;
     }
 
+    export function isExpressionFilter(filter: ExecuteAFM.CompatibilityFilter): filter is ExecuteAFM.IExpressionFilter {
+        return !isEmpty(filter) && (filter as ExecuteAFM.IExpressionFilter).value !== undefined;
+    }
+
     export function isAttributeElementsArray(attributeElements: AttributeElements): attributeElements is string[] {
         return attributeElements !== undefined && attributeElements instanceof Array;
     }

--- a/src/VisualizationInput.ts
+++ b/src/VisualizationInput.ts
@@ -30,7 +30,7 @@ export namespace VisualizationInput {
         measureDefinition: {
             item: ObjQualifier;
             aggregation?: MeasureAggregation;
-            filters?: IFilter[];
+            filters?: IMeasureFilter[];
             computeRatio?: boolean;
         };
     }
@@ -51,12 +51,20 @@ export namespace VisualizationInput {
     export type INegativeAttributeFilter = AFM.INegativeAttributeFilter;
     export type IAbsoluteDateFilter = VisualizationObject.IVisualizationObjectAbsoluteDateFilter;
     export type IRelativeDateFilter = VisualizationObject.IVisualizationObjectRelativeDateFilter;
+    export type IMeasureValueFilter = VisualizationObject.IMeasureValueFilter;
+
+    export type IMeasureFilter =
+        IAbsoluteDateFilter
+        | IRelativeDateFilter
+        | IPositiveAttributeFilter
+        | INegativeAttributeFilter;
 
     export type IFilter =
         IAbsoluteDateFilter
         | IRelativeDateFilter
         | IPositiveAttributeFilter
-        | INegativeAttributeFilter;
+        | INegativeAttributeFilter
+        | IMeasureValueFilter;
 
     export type ISort = AFM.IAttributeSortItem | AFM.IMeasureSortItem;
     export type ITotal = VisualizationObject.IVisualizationTotal;
@@ -99,6 +107,10 @@ export namespace VisualizationInput {
 
     export function isRelativeDateFilter(obj: any): obj is IRelativeDateFilter {
         return VisualizationObject.isRelativeDateFilter(obj);
+    }
+
+    export function isMeasureValueFilter(obj: any): obj is IMeasureValueFilter {
+        return VisualizationObject.isMeasureValueFilter(obj);
     }
 
     export function isSort(obj: any): obj is ISort {

--- a/src/tests/AFM.test.ts
+++ b/src/tests/AFM.test.ts
@@ -428,6 +428,52 @@ describe('AFM', () => {
         });
     });
 
+    const expressionFilter: CompatibilityFilter = {
+        value: 'MAQL'
+    };
+    const relativeDateFilter: CompatibilityFilter = {
+        relativeDateFilter: {
+            dataSet: {
+                uri: '/gdc/mock/ds'
+            },
+            granularity: 'gram',
+            from: -10,
+            to: 0
+        }
+    };
+    const absoluteDateFilter: CompatibilityFilter = {
+        absoluteDateFilter: {
+            dataSet: {
+                uri: '/gdc/mock/ds'
+            },
+            from: '1',
+            to: '2'
+        }
+    };
+    const negativeAttributeFilter: CompatibilityFilter = {
+        negativeAttributeFilter: {
+            displayForm: {
+                uri: '/gdc/mock/date'
+            },
+            notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+        }
+    };
+    const positiveAttributeFilter: CompatibilityFilter = {
+        positiveAttributeFilter: {
+            displayForm: {
+                uri: '/gdc/mock/attribute'
+            },
+            in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+        }
+    };
+    const measureValueFilter: CompatibilityFilter = {
+        measureValueFilter: {
+            measure: {
+                uri: '/gdc/mock/date'
+            }
+        }
+    };
+
     describe('isDateFilter', () => {
         it('should return false when null is tested', () => {
             const result = AFM.isDateFilter(null);
@@ -440,57 +486,32 @@ describe('AFM', () => {
         });
 
         it('should return true when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(relativeDateFilter);
             expect(result).toEqual(true);
         });
 
         it('should return true when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(absoluteDateFilter);
             expect(result).toEqual(true);
         });
 
         it('should return false when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(negativeAttributeFilter);
             expect(result).toEqual(false);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isDateFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -507,31 +528,32 @@ describe('AFM', () => {
         });
 
         it('should return true when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isRelativeDateFilter(filter);
+            const result = AFM.isRelativeDateFilter(relativeDateFilter);
             expect(result).toEqual(true);
         });
 
-        it('should return false when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isRelativeDateFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -547,33 +569,34 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return false when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isAbsoluteDateFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
         it('should return true when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isAbsoluteDateFilter(filter);
+            const result = AFM.isAbsoluteDateFilter(absoluteDateFilter);
             expect(result).toEqual(true);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(expressionFilter);
+            expect(result).toEqual(false);
         });
     });
 
@@ -588,58 +611,33 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
-            expect(result).toEqual(true);
-        });
-
-        it('should return true when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
-            expect(result).toEqual(true);
-        });
-
-        it('should return false when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isAttributeFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
-        it('should return false when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isAttributeFilter(negativeAttributeFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isAttributeFilter(positiveAttributeFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isAttributeFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -655,30 +653,34 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return false when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isPositiveAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
-        it('should return true when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isPositiveAttributeFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(positiveAttributeFilter);
             expect(result).toEqual(true);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(expressionFilter);
+            expect(result).toEqual(false);
         });
     });
 
@@ -693,29 +695,33 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isNegativeAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(negativeAttributeFilter);
             expect(result).toEqual(true);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isNegativeAttributeFilter(filter);
+            const result = AFM.isNegativeAttributeFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -731,29 +737,76 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when measure value filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                measureValueFilter: {
-                    measure: {
-                        uri: '/gdc/mock/date'
-                    }
-                }
-            };
-            const result = AFM.isMeasureValueFilter(filter);
-            expect(result).toEqual(true);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isMeasureValueFilter(filter);
+            const result = AFM.isMeasureValueFilter(positiveAttributeFilter);
             expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(measureValueFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(expressionFilter);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isExpressionFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isExpressionFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isExpressionFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isExpressionFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isExpressionFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isExpressionFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isExpressionFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isExpressionFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isExpressionFilter(expressionFilter);
+            expect(result).toEqual(true);
         });
     });
 });

--- a/src/tests/ExecuteAFM.test.ts
+++ b/src/tests/ExecuteAFM.test.ts
@@ -3,6 +3,52 @@ import { ExecuteAFM as AFM } from '../ExecuteAFM';
 import CompatibilityFilter = AFM.CompatibilityFilter;
 
 describe('AFM', () => {
+    const expressionFilter: CompatibilityFilter = {
+        value: 'MAQL'
+    };
+    const relativeDateFilter: CompatibilityFilter = {
+        relativeDateFilter: {
+            dataSet: {
+                uri: '/gdc/mock/ds'
+            },
+            granularity: 'gram',
+            from: -10,
+            to: 0
+        }
+    };
+    const absoluteDateFilter: CompatibilityFilter = {
+        absoluteDateFilter: {
+            dataSet: {
+                uri: '/gdc/mock/ds'
+            },
+            from: '1',
+            to: '2'
+        }
+    };
+    const negativeAttributeFilter: CompatibilityFilter = {
+        negativeAttributeFilter: {
+            displayForm: {
+                uri: '/gdc/mock/date'
+            },
+            notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+        }
+    };
+    const positiveAttributeFilter: CompatibilityFilter = {
+        positiveAttributeFilter: {
+            displayForm: {
+                uri: '/gdc/mock/attribute'
+            },
+            in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+        }
+    };
+    const measureValueFilter: CompatibilityFilter = {
+        measureValueFilter: {
+            measure: {
+                uri: '/gdc/mock/date'
+            }
+        }
+    };
+
     describe('isDateFilter', () => {
         it('should return false when null is tested', () => {
             const result = AFM.isDateFilter(null);
@@ -15,57 +61,32 @@ describe('AFM', () => {
         });
 
         it('should return true when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(relativeDateFilter);
             expect(result).toEqual(true);
         });
 
         it('should return true when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(absoluteDateFilter);
             expect(result).toEqual(true);
         });
 
         it('should return false when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(negativeAttributeFilter);
             expect(result).toEqual(false);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isDateFilter(filter);
+            const result = AFM.isDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isDateFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -82,31 +103,32 @@ describe('AFM', () => {
         });
 
         it('should return true when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isRelativeDateFilter(filter);
+            const result = AFM.isRelativeDateFilter(relativeDateFilter);
             expect(result).toEqual(true);
         });
 
-        it('should return false when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isRelativeDateFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isRelativeDateFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -122,33 +144,34 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return false when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isAbsoluteDateFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
         it('should return true when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isAbsoluteDateFilter(filter);
+            const result = AFM.isAbsoluteDateFilter(absoluteDateFilter);
             expect(result).toEqual(true);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isAbsoluteDateFilter(expressionFilter);
+            expect(result).toEqual(false);
         });
     });
 
@@ -163,58 +186,33 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
-            expect(result).toEqual(true);
-        });
-
-        it('should return true when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
-            expect(result).toEqual(true);
-        });
-
-        it('should return false when absolute date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                absoluteDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    from: '1',
-                    to: '2'
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isAttributeFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
-        it('should return false when relative date filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                relativeDateFilter: {
-                    dataSet: {
-                        uri: '/gdc/mock/ds'
-                    },
-                    granularity: 'gram',
-                    from: -10,
-                    to: 0
-                }
-            };
-            const result = AFM.isAttributeFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isAttributeFilter(negativeAttributeFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isAttributeFilter(positiveAttributeFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isAttributeFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -230,30 +228,34 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return false when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isPositiveAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(relativeDateFilter);
             expect(result).toEqual(false);
         });
 
-        it('should return true when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isPositiveAttributeFilter(filter);
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(positiveAttributeFilter);
             expect(result).toEqual(true);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isPositiveAttributeFilter(expressionFilter);
+            expect(result).toEqual(false);
         });
     });
 
@@ -268,29 +270,33 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when negative attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                negativeAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/date'
-                    },
-                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isNegativeAttributeFilter(filter);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(negativeAttributeFilter);
             expect(result).toEqual(true);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isNegativeAttributeFilter(filter);
+            const result = AFM.isNegativeAttributeFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isNegativeAttributeFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
@@ -306,114 +312,161 @@ describe('AFM', () => {
             expect(result).toEqual(false);
         });
 
-        it('should return true when measure value filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                measureValueFilter: {
-                    measure: {
-                        uri: '/gdc/mock/date'
-                    }
-                }
-            };
-            const result = AFM.isMeasureValueFilter(filter);
-            expect(result).toEqual(true);
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
         });
 
         it('should return false when positive attribute filter is tested', () => {
-            const filter: CompatibilityFilter = {
-                positiveAttributeFilter: {
-                    displayForm: {
-                        uri: '/gdc/mock/attribute'
-                    },
-                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
-                }
-            };
-            const result = AFM.isMeasureValueFilter(filter);
+            const result = AFM.isMeasureValueFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(measureValueFilter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isMeasureValueFilter(expressionFilter);
             expect(result).toEqual(false);
         });
     });
 
+    describe('isExpressionFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = AFM.isExpressionFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = AFM.isExpressionFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const result = AFM.isExpressionFilter(relativeDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const result = AFM.isExpressionFilter(absoluteDateFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const result = AFM.isExpressionFilter(negativeAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const result = AFM.isExpressionFilter(positiveAttributeFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure value filter is tested', () => {
+            const result = AFM.isExpressionFilter(measureValueFilter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when expression filter is tested', () => {
+            const result = AFM.isExpressionFilter(expressionFilter);
+            expect(result).toEqual(true);
+        });
+    });
+
     describe('isAttributeElementsArray', () => {
-        it ('should return false when null is tested', () => {
+        it('should return false when null is tested', () => {
             const result = AFM.isAttributeElementsArray(null);
             expect(result).toEqual(false);
         });
 
-        it ('should return false when undefined is tested', () => {
+        it('should return false when undefined is tested', () => {
             const result = AFM.isAttributeElementsArray(undefined);
             expect(result).toEqual(false);
         });
 
-        it ('should return false when attr elements by ref', () => {
+        it('should return false when attr elements by ref', () => {
             const result = AFM.isAttributeElementsArray({ uris: ['a', 'b', 'c'] });
             expect(result).toEqual(false);
         });
-        it ('should return false when attr elements by value', () => {
+        it('should return false when attr elements by value', () => {
             const result = AFM.isAttributeElementsArray({ values: ['a', 'b', 'c'] });
             expect(result).toEqual(false);
         });
-        it ('should return true when attr elements is array', () => {
+        it('should return true when attr elements is array', () => {
             const result = AFM.isAttributeElementsArray(['a', 'b', 'c']);
             expect(result).toEqual(true);
         });
-        it ('should return true when attr elements is empty array', () => {
+        it('should return true when attr elements is empty array', () => {
             const result = AFM.isAttributeElementsArray([]);
             expect(result).toEqual(true);
         });
     });
 
     describe('isAttributeElementsByRef', () => {
-        it ('should return false when null is tested', () => {
+        it('should return false when null is tested', () => {
             const result = AFM.isAttributeElementsByRef(null);
             expect(result).toEqual(false);
         });
 
-        it ('should return false when undefined is tested', () => {
+        it('should return false when undefined is tested', () => {
             const result = AFM.isAttributeElementsByRef(undefined);
             expect(result).toEqual(false);
         });
 
-        it ('should return true when attr elements by ref', () => {
+        it('should return true when attr elements by ref', () => {
             const result = AFM.isAttributeElementsByRef({ uris: ['a', 'b', 'c'] });
             expect(result).toEqual(true);
         });
-        it ('should return false when attr elements by value', () => {
+        it('should return false when attr elements by value', () => {
             const result = AFM.isAttributeElementsByRef({ values: ['a', 'b', 'c'] });
             expect(result).toEqual(false);
         });
-        it ('should return false when attr elements is array', () => {
+        it('should return false when attr elements is array', () => {
             const result = AFM.isAttributeElementsByRef(['a', 'b', 'c']);
             expect(result).toEqual(false);
         });
-        it ('should return false when attr elements is empty array', () => {
+        it('should return false when attr elements is empty array', () => {
             const result = AFM.isAttributeElementsByRef([]);
             expect(result).toEqual(false);
         });
     });
 
     describe('isAttributeElementsByValue', () => {
-        it ('should return false when null is tested', () => {
+        it('should return false when null is tested', () => {
             const result = AFM.isAttributeElementsByValue(null);
             expect(result).toEqual(false);
         });
 
-        it ('should return false when undefined is tested', () => {
+        it('should return false when undefined is tested', () => {
             const result = AFM.isAttributeElementsByValue(undefined);
             expect(result).toEqual(false);
         });
 
-        it ('should return false when attr elements by ref', () => {
+        it('should return false when attr elements by ref', () => {
             const result = AFM.isAttributeElementsByValue({ uris: ['a', 'b', 'c'] });
             expect(result).toEqual(false);
         });
-        it ('should return true when attr elements by value', () => {
+        it('should return true when attr elements by value', () => {
             const result = AFM.isAttributeElementsByValue({ values: ['a', 'b', 'c'] });
             expect(result).toEqual(true);
         });
-        it ('should return false when attr elements is array', () => {
+        it('should return false when attr elements is array', () => {
             const result = AFM.isAttributeElementsByValue(['a', 'b', 'c']);
             expect(result).toEqual(false);
         });
-        it ('should return false when attr elements is empty array', () => {
+        it('should return false when attr elements is empty array', () => {
             const result = AFM.isAttributeElementsByValue([]);
             expect(result).toEqual(false);
         });

--- a/src/tests/VisualizationInputs.test.ts
+++ b/src/tests/VisualizationInputs.test.ts
@@ -1,0 +1,504 @@
+// (C) 2019 GoodData Corporation
+import { VisualizationInput } from '../VisualizationInput';
+import IMeasure = VisualizationInput.IMeasure;
+import IMeasureDefinitionType = VisualizationInput.IMeasureDefinitionType;
+import IArithmeticMeasureDefinition = VisualizationInput.IArithmeticMeasureDefinition;
+
+describe('VisualizationObject', () => {
+    describe('isMeasure', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isMeasure(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isMeasure(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when visualization attribute is tested', () => {
+            const attribute: VisualizationInput.IAttribute = {
+                visualizationAttribute: {
+                    localIdentifier: 'm1',
+                    displayForm: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isMeasure(attribute);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when measure is tested', () => {
+            const measure: IMeasure = {
+                measure: {
+                    localIdentifier: 'm1',
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                uri: '/gdc/mock/measure'
+                            }
+                        }
+                    }
+                }
+            };
+            const result = VisualizationInput.isMeasure(measure);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isAttribute', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isAttribute(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isAttribute(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when measure is tested', () => {
+            const measure: IMeasure = {
+                measure: {
+                    localIdentifier: 'm1',
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                uri: '/gdc/mock/measure'
+                            }
+                        }
+                    }
+                }
+            };
+            const result = VisualizationInput.isAttribute(measure);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when visualization attribute is tested', () => {
+            const attribute: VisualizationInput.IAttribute = {
+                visualizationAttribute: {
+                    localIdentifier: 'm1',
+                    displayForm: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isAttribute(attribute);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isMeasureDefinition', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isMeasureDefinition(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isMeasureDefinition(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when simple measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                measureDefinition: {
+                    item: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isMeasureDefinition(measureDefinition);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when arithmetic measure definition is tested', () => {
+            const measureDefinition: IArithmeticMeasureDefinition = {
+                arithmeticMeasure: {
+                    measureIdentifiers: ['/gdc/mock/measure'],
+                    operator: 'sum'
+                }
+            };
+            const result = VisualizationInput.isMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when pop measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                popMeasureDefinition: {
+                    measureIdentifier: 'm1',
+                    popAttribute: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when previous period measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                previousPeriodMeasure: {
+                    measureIdentifier: 'm1',
+                    dateDataSets: [{
+                        dataSet: {
+                            uri: '/gdc/mock/date'
+                        },
+                        periodsAgo: 1
+                    }]
+                }
+            };
+            const result = VisualizationInput.isMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isArithmeticMeasureDefinition', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isArithmeticMeasureDefinition(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isArithmeticMeasureDefinition(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when simple measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                measureDefinition: {
+                    item: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isArithmeticMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when arithmetic measure definition is tested', () => {
+            const measureDefinition: IArithmeticMeasureDefinition = {
+                arithmeticMeasure: {
+                    measureIdentifiers: ['/gdc/mock/measure'],
+                    operator: 'sum'
+                }
+            };
+            const result = VisualizationInput.isArithmeticMeasureDefinition(measureDefinition);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when pop measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                popMeasureDefinition: {
+                    measureIdentifier: 'm1',
+                    popAttribute: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isArithmeticMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when previous period measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                previousPeriodMeasure: {
+                    measureIdentifier: 'm1',
+                    dateDataSets: [{
+                        dataSet: {
+                            uri: '/gdc/mock/date'
+                        },
+                        periodsAgo: 1
+                    }]
+                }
+            };
+            const result = VisualizationInput.isArithmeticMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isPopMeasureDefinition', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isPopMeasureDefinition(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isPopMeasureDefinition(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when simple measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                measureDefinition: {
+                    item: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isPopMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when arithmetic measure definition is tested', () => {
+            const measureDefinition: IArithmeticMeasureDefinition = {
+                arithmeticMeasure: {
+                    measureIdentifiers: ['/gdc/mock/measure'],
+                    operator: 'sum'
+                }
+            };
+            const result = VisualizationInput.isPopMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when pop measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                popMeasureDefinition: {
+                    measureIdentifier: 'm1',
+                    popAttribute: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isPopMeasureDefinition(measureDefinition);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when previous period measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                previousPeriodMeasure: {
+                    measureIdentifier: 'm1',
+                    dateDataSets: [{
+                        dataSet: {
+                            uri: '/gdc/mock/date'
+                        },
+                        periodsAgo: 1
+                    }]
+                }
+            };
+            const result = VisualizationInput.isMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('isPreviousPeriodMeasureDefinition', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when simple measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                measureDefinition: {
+                    item: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when arithmetic measure definition is tested', () => {
+            const measureDefinition: IArithmeticMeasureDefinition = {
+                arithmeticMeasure: {
+                    measureIdentifiers: ['/gdc/mock/measure'],
+                    operator: 'sum'
+                }
+            };
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when pop measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                popMeasureDefinition: {
+                    measureIdentifier: 'm1',
+                    popAttribute: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(measureDefinition);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when previous period measure definition is tested', () => {
+            const measureDefinition: IMeasureDefinitionType = {
+                previousPeriodMeasure: {
+                    measureIdentifier: 'm1',
+                    dateDataSets: [{
+                        dataSet: {
+                            uri: '/gdc/mock/date'
+                        },
+                        periodsAgo: 1
+                    }]
+                }
+            };
+            const result = VisualizationInput.isPreviousPeriodMeasureDefinition(measureDefinition);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isPositiveAttributeFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isPositiveAttributeFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isPositiveAttributeFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when negative attribute filter is tested', () => {
+            const filter: VisualizationInput.INegativeAttributeFilter = {
+                negativeAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/date'
+                    },
+                    notIn: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = VisualizationInput.isPositiveAttributeFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when positive attribute filter is tested', () => {
+            const filter: VisualizationInput.IPositiveAttributeFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = VisualizationInput.isPositiveAttributeFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isAbsoluteDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isAbsoluteDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isAbsoluteDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when relative date filter is tested', () => {
+            const filter: VisualizationInput.IRelativeDateFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    granularity: 'GDC.time.year',
+                    from: -1,
+                    to: -1
+                }
+            };
+            const result = VisualizationInput.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when absolute date filter is tested', () => {
+            const filter: VisualizationInput.IAbsoluteDateFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    from: '2017-06-12',
+                    to: '2018-07-11'
+                }
+            };
+            const result = VisualizationInput.isAbsoluteDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isRelativeDateFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isRelativeDateFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isRelativeDateFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when absolute date filter is tested', () => {
+            const filter: VisualizationInput.IAbsoluteDateFilter = {
+                absoluteDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    from: 'beginning',
+                    to: 'to end'
+                }
+            };
+            const result = VisualizationInput.isRelativeDateFilter(filter);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when relative date filter is tested', () => {
+            const filter: VisualizationInput.IRelativeDateFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        uri: '/gdc/mock/date'
+                    },
+                    granularity: 'GDC.time.year',
+                    from: -1,
+                    to: -1
+                }
+            };
+            const result = VisualizationInput.isRelativeDateFilter(filter);
+            expect(result).toEqual(true);
+        });
+    });
+
+    describe('isMeasureValueFilter', () => {
+        it('should return false when null is tested', () => {
+            const result = VisualizationInput.isMeasureValueFilter(null);
+            expect(result).toEqual(false);
+        });
+
+        it('should return false when undefined is tested', () => {
+            const result = VisualizationInput.isMeasureValueFilter(undefined);
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when measure value filter is tested', () => {
+            const filter: VisualizationInput.IMeasureValueFilter = {
+                measureValueFilter: {
+                    measure: {
+                        uri: '/gdc/mock/measure'
+                    }
+                }
+            };
+            const result = VisualizationInput.isMeasureValueFilter(filter);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when positive attribute filter is tested', () => {
+            const filter: VisualizationInput.IPositiveAttributeFilter = {
+                positiveAttributeFilter: {
+                    displayForm: {
+                        uri: '/gdc/mock/attribute'
+                    },
+                    in: ['/gdc/mock/attribute/value_1', '/gdc/mock/attribute/value_2']
+                }
+            };
+            const result = VisualizationInput.isMeasureValueFilter(filter);
+            expect(result).toEqual(false);
+        });
+    });
+});


### PR DESCRIPTION
IMeasureDefinition use a new type IMeasureFilter that consists only from types supported as measure filters. Previously used IFilter interface was extended with new IMeasureValueFilter that is not supported on measure level, only on a visualization level.